### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-flux-schema.yaml
+++ b/.github/workflows/validate-flux-schema.yaml
@@ -1,5 +1,8 @@
 name: Validate cluster config
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/tim83/fluxcd/security/code-scanning/2](https://github.com/tim83/fluxcd/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Since the workflow primarily validates manifests and does not perform any write operations, we will set `contents: read` as the permission. This ensures that the workflow has only read access to the repository contents, minimizing security risks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
